### PR TITLE
docs: add Mantine 9.3 window menu demos

### DIFF
--- a/docs/demos/Window.demo.contextMenu.tsx
+++ b/docs/demos/Window.demo.contextMenu.tsx
@@ -1,0 +1,125 @@
+import { Window } from '@gfazioli/mantine-window';
+import { Box, Menu, Paper, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { IconArrowsMaximize, IconCopy, IconPinned, IconTrash } from '@tabler/icons-react';
+
+const code = `import { Window } from '@gfazioli/mantine-window';
+import { Box, Menu, Paper, Text } from '@mantine/core';
+import {
+  IconArrowsMaximize,
+  IconCopy,
+  IconPinned,
+  IconTrash,
+} from '@tabler/icons-react';
+
+function Demo() {
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 500 }}>
+      <Window
+        title="Project Files"
+        opened
+        defaultX={40}
+        defaultY={40}
+        defaultWidth={360}
+        defaultHeight={260}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Menu shadow="md" width={220} withArrow>
+          <Menu.ContextMenu>
+            <Paper
+              withBorder
+              radius="md"
+              p="lg"
+              style={{
+                minHeight: 150,
+                userSelect: 'none',
+                background: 'var(--mantine-color-gray-0)',
+              }}
+            >
+              <Text fw={600}>Right-click anywhere in this workspace</Text>
+              <Text c="dimmed" size="sm" mt={6}>
+                The menu opens at the cursor to mimic desktop window actions.
+              </Text>
+            </Paper>
+          </Menu.ContextMenu>
+
+          <Menu.Dropdown>
+            <Menu.Label>Window actions</Menu.Label>
+            <Menu.Item leftSection={<IconArrowsMaximize size={14} />}>
+              Maximize
+            </Menu.Item>
+            <Menu.Item leftSection={<IconCopy size={14} />}>
+              Duplicate
+            </Menu.Item>
+            <Menu.Item leftSection={<IconPinned size={14} />}>
+              Pin to workspace
+            </Menu.Item>
+            <Menu.Divider />
+            <Menu.Item color="red" leftSection={<IconTrash size={14} />}>
+              Close window
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Window>
+    </Box>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 500 }}>
+      <Window
+        title="Project Files"
+        opened
+        defaultX={40}
+        defaultY={40}
+        defaultWidth={360}
+        defaultHeight={260}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Menu shadow="md" width={220} withArrow>
+          <Menu.ContextMenu>
+            <Paper
+              withBorder
+              radius="md"
+              p="lg"
+              style={{
+                minHeight: 150,
+                userSelect: 'none',
+                background: 'var(--mantine-color-gray-0)',
+              }}
+            >
+              <Text fw={600}>Right-click anywhere in this workspace</Text>
+              <Text c="dimmed" size="sm" mt={6}>
+                The menu opens at the cursor to mimic desktop window actions.
+              </Text>
+            </Paper>
+          </Menu.ContextMenu>
+
+          <Menu.Dropdown>
+            <Menu.Label>Window actions</Menu.Label>
+            <Menu.Item leftSection={<IconArrowsMaximize size={14} />}>Maximize</Menu.Item>
+            <Menu.Item leftSection={<IconCopy size={14} />}>Duplicate</Menu.Item>
+            <Menu.Item leftSection={<IconPinned size={14} />}>Pin to workspace</Menu.Item>
+            <Menu.Divider />
+            <Menu.Item color="red" leftSection={<IconTrash size={14} />}>
+              Close window
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Window>
+    </Box>
+  );
+}
+
+export const contextMenu: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/Window.demo.menuBar.tsx
+++ b/docs/demos/Window.demo.menuBar.tsx
@@ -1,0 +1,233 @@
+import { Window } from '@gfazioli/mantine-window';
+import { Badge, Box, Button, Group, Menu, Stack, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { IconCheck } from '@tabler/icons-react';
+import { useState } from 'react';
+
+const code = `import { useState } from 'react';
+import { Window } from '@gfazioli/mantine-window';
+import { Badge, Box, Button, Group, Menu, Stack, Text } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
+
+const commands = [
+  'New note',
+  'Rename workspace',
+  'Move window left',
+  'Move window right',
+  'Toggle command bar',
+  'Open recent project',
+];
+
+function Demo() {
+  const [query, setQuery] = useState('');
+  const [showGrid, setShowGrid] = useState(true);
+  const [showRulers, setShowRulers] = useState(false);
+  const [density, setDensity] = useState('comfortable');
+
+  const filteredCommands = commands.filter((item) =>
+    item.toLowerCase().includes(query.toLowerCase().trim())
+  );
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 520 }}>
+      <Window
+        title="Design Workspace"
+        opened
+        defaultX={30}
+        defaultY={30}
+        defaultWidth={420}
+        defaultHeight={300}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Stack gap="md">
+          <Group gap={6} wrap="nowrap">
+            <Menu shadow="md" width={250}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  File
+                </Button>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Search
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder="Search commands"
+                />
+
+                {filteredCommands.length > 0 ? (
+                  filteredCommands.map((item) => <Menu.Item key={item}>{item}</Menu.Item>)
+                ) : (
+                  <Text c="dimmed" size="sm" ta="center" py="xs">
+                    Nothing found
+                  </Text>
+                )}
+              </Menu.Dropdown>
+            </Menu>
+
+            <Menu shadow="md" width={240} closeOnItemClick={false}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  View
+                </Button>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Label>Canvas options</Menu.Label>
+                <Menu.CheckboxItem
+                  checked={showGrid}
+                  onChange={setShowGrid}
+                >
+                  Show grid
+                </Menu.CheckboxItem>
+                <Menu.CheckboxItem
+                  checked={showRulers}
+                  onChange={setShowRulers}
+                >
+                  Show rulers
+                </Menu.CheckboxItem>
+                <Menu.Divider />
+                <Menu.Label>Density</Menu.Label>
+                <Menu.RadioGroup value={density} onChange={setDensity}>
+                  <Menu.RadioItem value="compact">Compact</Menu.RadioItem>
+                  <Menu.RadioItem value="comfortable">Comfortable</Menu.RadioItem>
+                  <Menu.RadioItem value="spacious">Spacious</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+
+          <Group gap="xs">
+            <Badge variant={showGrid ? 'filled' : 'light'} leftSection={<IconCheck size={10} />}>
+              Grid {showGrid ? 'on' : 'off'}
+            </Badge>
+            <Badge
+              variant={showRulers ? 'filled' : 'light'}
+              leftSection={<IconCheck size={10} />}
+            >
+              Rulers {showRulers ? 'on' : 'off'}
+            </Badge>
+            <Badge variant="light">Density: {density}</Badge>
+          </Group>
+
+          <Text c="dimmed" size="sm">
+            This menu bar keeps desktop-style window controls close to the content.
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+`;
+
+const commands = [
+  'New note',
+  'Rename workspace',
+  'Move window left',
+  'Move window right',
+  'Toggle command bar',
+  'Open recent project',
+];
+
+function Demo() {
+  const [query, setQuery] = useState('');
+  const [showGrid, setShowGrid] = useState(true);
+  const [showRulers, setShowRulers] = useState(false);
+  const [density, setDensity] = useState('comfortable');
+
+  const filteredCommands = commands.filter((item) =>
+    item.toLowerCase().includes(query.toLowerCase().trim())
+  );
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 520 }}>
+      <Window
+        title="Design Workspace"
+        opened
+        defaultX={30}
+        defaultY={30}
+        defaultWidth={420}
+        defaultHeight={300}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Stack gap="md">
+          <Group gap={6} wrap="nowrap">
+            <Menu shadow="md" width={250}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  File
+                </Button>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Search
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder="Search commands"
+                />
+
+                {filteredCommands.length > 0 ? (
+                  filteredCommands.map((item) => <Menu.Item key={item}>{item}</Menu.Item>)
+                ) : (
+                  <Text c="dimmed" size="sm" ta="center" py="xs">
+                    Nothing found
+                  </Text>
+                )}
+              </Menu.Dropdown>
+            </Menu>
+
+            <Menu shadow="md" width={240} closeOnItemClick={false}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  View
+                </Button>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Label>Canvas options</Menu.Label>
+                <Menu.CheckboxItem checked={showGrid} onChange={setShowGrid}>
+                  Show grid
+                </Menu.CheckboxItem>
+                <Menu.CheckboxItem checked={showRulers} onChange={setShowRulers}>
+                  Show rulers
+                </Menu.CheckboxItem>
+                <Menu.Divider />
+                <Menu.Label>Density</Menu.Label>
+                <Menu.RadioGroup value={density} onChange={setDensity}>
+                  <Menu.RadioItem value="compact">Compact</Menu.RadioItem>
+                  <Menu.RadioItem value="comfortable">Comfortable</Menu.RadioItem>
+                  <Menu.RadioItem value="spacious">Spacious</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+
+          <Group gap="xs">
+            <Badge variant={showGrid ? 'filled' : 'light'} leftSection={<IconCheck size={10} />}>
+              Grid {showGrid ? 'on' : 'off'}
+            </Badge>
+            <Badge variant={showRulers ? 'filled' : 'light'} leftSection={<IconCheck size={10} />}>
+              Rulers {showRulers ? 'on' : 'off'}
+            </Badge>
+            <Badge variant="light">Density: {density}</Badge>
+          </Group>
+
+          <Text c="dimmed" size="sm">
+            This menu bar keeps desktop-style window controls close to the content.
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+
+export const menuBar: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -1,6 +1,7 @@
 export { callbacks } from './Window.demo.callbacks';
 export { centered } from './Window.demo.centered';
 export { configurator } from './Window.demo.configurator';
+export { contextMenu } from './Window.demo.contextMenu';
 export { controlsPositionDemo } from './Window.demo.controlsPosition';
 export { controlled } from './Window.demo.controlled';
 export { controlledPosition } from './Window.demo.controlledPosition';
@@ -13,6 +14,7 @@ export { layoutPresets } from './Window.demo.layoutPresets';
 export { minMaxSize } from './Window.demo.minMaxSize';
 export { mixedConstraints } from './Window.demo.mixedConstraints';
 export { mixedDragBounds } from './Window.demo.mixedDragBounds';
+export { menuBar } from './Window.demo.menuBar';
 export { multiple } from './Window.demo.multiple';
 export { noCollapsable } from './Window.demo.noCollapsable';
 export { persistence } from './Window.demo.persistence';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -166,6 +166,18 @@ You can render multiple windows in the same container. Each window maintains its
 
 <Demo data={demos.multiple} />
 
+## Context Menu
+
+Mantine 9.3 adds `Menu.ContextMenu`, which lets you attach desktop-style right-click actions to a single trigger surface. This pairs well with `Window` when you want file panes, canvases, or desktop areas to open actions exactly where the user clicks.
+
+<Demo data={demos.contextMenu} />
+
+## Window Menu Bar
+
+`Menu.Search`, `Menu.CheckboxItem`, and `Menu.RadioGroup` make it easy to build a compact menu bar inside a window. Use the pattern below for searchable command menus, toggleable view options, and mutually exclusive layout settings.
+
+<Demo data={demos.menuBar} />
+
 ## Window.Group
 
 Wrap multiple windows in a `Window.Group` to enable coordinated window management. The group provides:


### PR DESCRIPTION
## Summary
- add a `Menu.ContextMenu` demo that shows desktop-style right-click actions inside a `Window`
- add a window menu bar demo that combines `Menu.Search`, `Menu.CheckboxItem`, and `Menu.RadioGroup`
- document both patterns in `docs/docs.mdx` and export them from the demo index

Closes #30.

## Validation
- `yarn build`
- `yarn docs:build`
- `yarn format:test`
- `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added context menu example demonstrating right-click menu functionality for the Window component
* Added menu bar example showing searchable command menus with toggles and filter options
* Updated documentation with two new Window usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->