### PR TITLE
docs: add Mantine 9.3 context menu and window menu bar demos

### DIFF
--- a/docs/demos/Window.demo.contextMenu.tsx
+++ b/docs/demos/Window.demo.contextMenu.tsx
@@ -1,0 +1,160 @@
+import { Window } from '@gfazioli/mantine-window';
+import { Box, Button, Center, Menu, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { IconCopy, IconX } from '@tabler/icons-react';
+import { useState } from 'react';
+
+const code = `import { useState } from 'react';
+import { Window } from '@gfazioli/mantine-window';
+import { Box, Button, Center, Menu, Text } from '@mantine/core';
+import { IconCopy, IconX } from '@tabler/icons-react';
+
+type Pane = { id: number; x: number; y: number };
+
+function Demo() {
+  const [panes, setPanes] = useState<Pane[]>([{ id: 1, x: 40, y: 40 }]);
+  const [nextId, setNextId] = useState(2);
+
+  const openPane = (x: number, y: number) => {
+    setPanes((current) => [...current, { id: nextId, x, y }]);
+    setNextId((id) => id + 1);
+  };
+
+  const closePane = (id: number) => {
+    setPanes((current) => current.filter((pane) => pane.id !== id));
+  };
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 480 }}>
+      {panes.length === 0 && (
+        <Center h="100%">
+          <Button onClick={() => openPane(40, 40)}>Open a window</Button>
+        </Center>
+      )}
+
+      {panes.map((pane) => (
+        <Window
+          key={pane.id}
+          title={\`Window \${pane.id}\`}
+          opened
+          defaultX={pane.x}
+          defaultY={pane.y}
+          defaultWidth={320}
+          defaultHeight={220}
+          persistState={false}
+          withinPortal={false}
+          withScrollArea={false}
+          onClose={() => closePane(pane.id)}
+        >
+          <Menu shadow="md" width={210} withArrow>
+            <Menu.ContextMenu>
+              <Box p="md" h="100%" style={{ userSelect: 'none' }}>
+                <Text fw={600}>Right-click here</Text>
+                <Text c="dimmed" size="sm" mt={4}>
+                  The context menu actions really drive this window: duplicate it or close it.
+                </Text>
+              </Box>
+            </Menu.ContextMenu>
+
+            <Menu.Dropdown>
+              <Menu.Label>Window {pane.id}</Menu.Label>
+              <Menu.Item
+                leftSection={<IconCopy size={14} />}
+                onClick={() => openPane(pane.x + 48, pane.y + 48)}
+              >
+                Duplicate window
+              </Menu.Item>
+              <Menu.Divider />
+              <Menu.Item
+                color="red"
+                leftSection={<IconX size={14} />}
+                onClick={() => closePane(pane.id)}
+              >
+                Close window
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        </Window>
+      ))}
+    </Box>
+  );
+}
+`;
+
+type Pane = { id: number; x: number; y: number };
+
+function Demo() {
+  const [panes, setPanes] = useState<Pane[]>([{ id: 1, x: 40, y: 40 }]);
+  const [nextId, setNextId] = useState(2);
+
+  const openPane = (x: number, y: number) => {
+    setPanes((current) => [...current, { id: nextId, x, y }]);
+    setNextId((id) => id + 1);
+  };
+
+  const closePane = (id: number) => {
+    setPanes((current) => current.filter((pane) => pane.id !== id));
+  };
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 480 }}>
+      {panes.length === 0 && (
+        <Center h="100%">
+          <Button onClick={() => openPane(40, 40)}>Open a window</Button>
+        </Center>
+      )}
+
+      {panes.map((pane) => (
+        <Window
+          key={pane.id}
+          title={`Window ${pane.id}`}
+          opened
+          defaultX={pane.x}
+          defaultY={pane.y}
+          defaultWidth={320}
+          defaultHeight={220}
+          persistState={false}
+          withinPortal={false}
+          withScrollArea={false}
+          onClose={() => closePane(pane.id)}
+        >
+          <Menu shadow="md" width={210} withArrow>
+            <Menu.ContextMenu>
+              <Box p="md" h="100%" style={{ userSelect: 'none' }}>
+                <Text fw={600}>Right-click here</Text>
+                <Text c="dimmed" size="sm" mt={4}>
+                  The context menu actions really drive this window: duplicate it or close it.
+                </Text>
+              </Box>
+            </Menu.ContextMenu>
+
+            <Menu.Dropdown>
+              <Menu.Label>Window {pane.id}</Menu.Label>
+              <Menu.Item
+                leftSection={<IconCopy size={14} />}
+                onClick={() => openPane(pane.x + 48, pane.y + 48)}
+              >
+                Duplicate window
+              </Menu.Item>
+              <Menu.Divider />
+              <Menu.Item
+                color="red"
+                leftSection={<IconX size={14} />}
+                onClick={() => closePane(pane.id)}
+              >
+                Close window
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        </Window>
+      ))}
+    </Box>
+  );
+}
+
+export const contextMenu: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/Window.demo.menuBar.tsx
+++ b/docs/demos/Window.demo.menuBar.tsx
@@ -1,0 +1,310 @@
+import { Window } from '@gfazioli/mantine-window';
+import { Box, Button, Group, Menu, Paper, Stack, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { useState } from 'react';
+
+const code = `import { useState } from 'react';
+import { Window } from '@gfazioli/mantine-window';
+import { Box, Button, Group, Menu, Paper, Stack, Text } from '@mantine/core';
+
+const densities = { compact: 'xs', comfortable: 'sm', spacious: 'lg' } as const;
+
+function Demo() {
+  const [query, setQuery] = useState('');
+  const [layers, setLayers] = useState(['Layer 1', 'Layer 2']);
+  const [nextLayer, setNextLayer] = useState(3);
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const [showGrid, setShowGrid] = useState(true);
+  const [density, setDensity] = useState<keyof typeof densities>('comfortable');
+
+  // Every File command really operates on the canvas
+  const commands = [
+    {
+      label: 'New layer',
+      action: () => {
+        setLayers((current) => [...current, \`Layer \${nextLayer}\`]);
+        setNextLayer((n) => n + 1);
+      },
+    },
+    {
+      label: 'Duplicate layer',
+      action: () => {
+        setLayers((current) =>
+          current.length > 0 ? [...current, \`\${current[current.length - 1]} copy\`] : current
+        );
+      },
+    },
+    {
+      label: 'Remove layer',
+      action: () => setLayers((current) => current.slice(0, -1)),
+    },
+    { label: 'Export as PNG', action: () => {} },
+  ];
+
+  const filtered = commands.filter((command) =>
+    command.label.toLowerCase().includes(query.trim().toLowerCase())
+  );
+
+  const runCommand = (command: (typeof commands)[number]) => {
+    command.action();
+    setLastAction(command.label);
+  };
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 520 }}>
+      <Window
+        title="Design Workspace"
+        opened
+        defaultX={30}
+        defaultY={30}
+        defaultWidth={440}
+        defaultHeight={340}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Stack gap="sm" h="100%">
+          {/* The menu bar */}
+          <Group gap={4}>
+            <Menu shadow="md" width={240} position="bottom-start">
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  File
+                </Button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Search
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder="Search commands"
+                />
+                {filtered.length > 0 ? (
+                  filtered.map((command) => (
+                    <Menu.Item key={command.label} onClick={() => runCommand(command)}>
+                      {command.label}
+                    </Menu.Item>
+                  ))
+                ) : (
+                  <Text c="dimmed" size="sm" ta="center" py="xs">
+                    Nothing found
+                  </Text>
+                )}
+              </Menu.Dropdown>
+            </Menu>
+
+            <Menu shadow="md" width={220} position="bottom-start" closeOnItemClick={false}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  View
+                </Button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Label>Canvas</Menu.Label>
+                <Menu.CheckboxItem checked={showGrid} onChange={setShowGrid}>
+                  Show grid
+                </Menu.CheckboxItem>
+                <Menu.Divider />
+                <Menu.Label>Density</Menu.Label>
+                <Menu.RadioGroup
+                  value={density}
+                  onChange={(value) => setDensity(value as keyof typeof densities)}
+                >
+                  <Menu.RadioItem value="compact">Compact</Menu.RadioItem>
+                  <Menu.RadioItem value="comfortable">Comfortable</Menu.RadioItem>
+                  <Menu.RadioItem value="spacious">Spacious</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+
+          {/* The canvas: layers, grid and density all react to the menus */}
+          <Box
+            flex={1}
+            p="sm"
+            style={{
+              overflow: 'auto',
+              borderRadius: 'var(--mantine-radius-sm)',
+              border: '1px solid var(--mantine-color-default-border)',
+              backgroundImage: showGrid
+                ? 'radial-gradient(var(--mantine-color-default-border) 1px, transparent 0)'
+                : undefined,
+              backgroundSize: '16px 16px',
+            }}
+          >
+            {layers.length > 0 ? (
+              <Stack gap={densities[density]}>
+                {layers.map((layer, index) => (
+                  <Paper key={index} withBorder p={densities[density]}>
+                    {layer}
+                  </Paper>
+                ))}
+              </Stack>
+            ) : (
+              <Text c="dimmed" size="sm" ta="center" py="lg">
+                No layers — use File → New layer
+              </Text>
+            )}
+          </Box>
+
+          {/* Status bar: File menu commands land here */}
+          <Text size="xs" c="dimmed">
+            {lastAction ? \`Last action: \${lastAction}\` : 'Run a command from the File menu'}
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+`;
+
+const densities = { compact: 'xs', comfortable: 'sm', spacious: 'lg' } as const;
+
+function Demo() {
+  const [query, setQuery] = useState('');
+  const [layers, setLayers] = useState(['Layer 1', 'Layer 2']);
+  const [nextLayer, setNextLayer] = useState(3);
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const [showGrid, setShowGrid] = useState(true);
+  const [density, setDensity] = useState<keyof typeof densities>('comfortable');
+
+  const commands = [
+    {
+      label: 'New layer',
+      action: () => {
+        setLayers((current) => [...current, `Layer ${nextLayer}`]);
+        setNextLayer((n) => n + 1);
+      },
+    },
+    {
+      label: 'Duplicate layer',
+      action: () => {
+        setLayers((current) =>
+          current.length > 0 ? [...current, `${current[current.length - 1]} copy`] : current
+        );
+      },
+    },
+    {
+      label: 'Remove layer',
+      action: () => setLayers((current) => current.slice(0, -1)),
+    },
+    { label: 'Export as PNG', action: () => {} },
+  ];
+
+  const filtered = commands.filter((command) =>
+    command.label.toLowerCase().includes(query.trim().toLowerCase())
+  );
+
+  const runCommand = (command: (typeof commands)[number]) => {
+    command.action();
+    setLastAction(command.label);
+  };
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 520 }}>
+      <Window
+        title="Design Workspace"
+        opened
+        defaultX={30}
+        defaultY={30}
+        defaultWidth={440}
+        defaultHeight={340}
+        persistState={false}
+        withinPortal={false}
+        withScrollArea={false}
+      >
+        <Stack gap="sm" h="100%">
+          <Group gap={4}>
+            <Menu shadow="md" width={240} position="bottom-start">
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  File
+                </Button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Search
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder="Search commands"
+                />
+                {filtered.length > 0 ? (
+                  filtered.map((command) => (
+                    <Menu.Item key={command.label} onClick={() => runCommand(command)}>
+                      {command.label}
+                    </Menu.Item>
+                  ))
+                ) : (
+                  <Text c="dimmed" size="sm" ta="center" py="xs">
+                    Nothing found
+                  </Text>
+                )}
+              </Menu.Dropdown>
+            </Menu>
+
+            <Menu shadow="md" width={220} position="bottom-start" closeOnItemClick={false}>
+              <Menu.Target>
+                <Button variant="subtle" color="gray" size="compact-sm">
+                  View
+                </Button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Label>Canvas</Menu.Label>
+                <Menu.CheckboxItem checked={showGrid} onChange={setShowGrid}>
+                  Show grid
+                </Menu.CheckboxItem>
+                <Menu.Divider />
+                <Menu.Label>Density</Menu.Label>
+                <Menu.RadioGroup
+                  value={density}
+                  onChange={(value) => setDensity(value as keyof typeof densities)}
+                >
+                  <Menu.RadioItem value="compact">Compact</Menu.RadioItem>
+                  <Menu.RadioItem value="comfortable">Comfortable</Menu.RadioItem>
+                  <Menu.RadioItem value="spacious">Spacious</Menu.RadioItem>
+                </Menu.RadioGroup>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+
+          <Box
+            flex={1}
+            p="sm"
+            style={{
+              overflow: 'auto',
+              borderRadius: 'var(--mantine-radius-sm)',
+              border: '1px solid var(--mantine-color-default-border)',
+              backgroundImage: showGrid
+                ? 'radial-gradient(var(--mantine-color-default-border) 1px, transparent 0)'
+                : undefined,
+              backgroundSize: '16px 16px',
+            }}
+          >
+            {layers.length > 0 ? (
+              <Stack gap={densities[density]}>
+                {layers.map((layer, index) => (
+                  <Paper key={index} withBorder p={densities[density]}>
+                    {layer}
+                  </Paper>
+                ))}
+              </Stack>
+            ) : (
+              <Text c="dimmed" size="sm" ta="center" py="lg">
+                No layers — use File → New layer
+              </Text>
+            )}
+          </Box>
+
+          <Text size="xs" c="dimmed">
+            {lastAction ? `Last action: ${lastAction}` : 'Run a command from the File menu'}
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+
+export const menuBar: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -1,6 +1,7 @@
 export { callbacks } from './Window.demo.callbacks';
 export { centered } from './Window.demo.centered';
 export { configurator } from './Window.demo.configurator';
+export { contextMenu } from './Window.demo.contextMenu';
 export { controlsPositionDemo } from './Window.demo.controlsPosition';
 export { controlled } from './Window.demo.controlled';
 export { controlledPosition } from './Window.demo.controlledPosition';
@@ -10,6 +11,7 @@ export { fullSizeHandles } from './Window.demo.fullSizeHandles';
 export { group } from './Window.demo.group';
 export { groupLayout } from './Window.demo.groupLayout';
 export { layoutPresets } from './Window.demo.layoutPresets';
+export { menuBar } from './Window.demo.menuBar';
 export { minMaxSize } from './Window.demo.minMaxSize';
 export { mixedConstraints } from './Window.demo.mixedConstraints';
 export { mixedDragBounds } from './Window.demo.mixedDragBounds';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -166,6 +166,24 @@ You can render multiple windows in the same container. Each window maintains its
 
 <Demo data={demos.multiple} />
 
+## Context Menu
+
+Mantine 9.3 introduces the Menu.ContextMenu component: attach desktop-style right-click
+actions to any surface. Inside a Window it completes the desktop metaphor — and in this
+demo the actions are real: duplicate the window or close it, with the windows rendered
+dynamically from state.
+
+<Demo data={demos.contextMenu} />
+
+## Window Menu Bar
+
+The Menu.Search, Menu.CheckboxItem and Menu.RadioGroup components added in Mantine 9.3
+make a compact in-window menu bar straightforward. In this demo every menu entry drives
+the workspace for real: the searchable File menu reports the executed command in the
+status bar, while the View menu toggles the canvas grid and changes the layout density.
+
+<Demo data={demos.menuBar} />
+
 ## Window.Group
 
 Wrap multiple windows in a `Window.Group` to enable coordinated window management. The group provides:


### PR DESCRIPTION
## Summary

Implements #30 with demos where **every menu entry drives real state** — completing the desktop metaphor instead of showing inert items:

- **Context Menu** (`Menu.ContextMenu`): windows rendered dynamically from state via `.map()` — *Duplicate window* spawns a new one at an offset, *Close window* removes it, empty state offers a reopen button
- **Window Menu Bar**: searchable **File** menu (`Menu.Search`) whose commands create/duplicate/remove canvas layers and land in a status bar; **View** menu (`Menu.CheckboxItem`, `Menu.RadioGroup`, `closeOnItemClick={false}`) toggles the canvas grid and changes layout density live
- Theme-aware tokens only (works in dark mode), `MantineDemo` shape, mdx headings without inline code

Alternative to #31 — thanks @ded-furby for the first take.

Closes #30

## Test plan
- [x] yarn test passes (150/150)
- [x] yarn build succeeds
- [x] Demos verified live at localhost:9281 (light + dark)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive demo and documentation for context menus within windows, including patterns for opening new windows, duplicating instances with offset positioning, and closing windows via context actions.
  * Added comprehensive demo and documentation for window menu bars, showcasing File and View menu implementations with features like search filtering, grid visibility toggling, and density selection controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->