### PR TITLE
fix: inline window control icons to drop @tabler/icons-react barrel import

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -41,7 +41,6 @@
   "peerDependencies": {
     "@mantine/core": ">=9.0.0",
     "@mantine/hooks": ">=9.0.0",
-    "@tabler/icons-react": "^3.34.0",
     "react": "^18.x || ^19.x",
     "react-dom": "^18.x || ^19.x"
   },

--- a/package/src/ControlIcons.tsx
+++ b/package/src/ControlIcons.tsx
@@ -26,6 +26,7 @@ function ControlIcon({ size = 24, children }: React.PropsWithChildren<ControlIco
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
+      aria-hidden="true"
     >
       {children}
     </svg>

--- a/package/src/ControlIcons.tsx
+++ b/package/src/ControlIcons.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+interface ControlIconProps {
+  size?: number;
+}
+
+/**
+ * Inline replicas of the three `@tabler/icons-react` outline icons used by the
+ * window controls (x, plus, minus).
+ *
+ * Inlining them removes `@tabler/icons-react` as a peer dependency and avoids
+ * the `LARGE_BARREL_MODULES` warning that the Rolldown/Vite dependency
+ * optimizer raises when it has to resolve every entry of Tabler's 6000+
+ * re-export barrel module (see issue #39). Geometry and stroke attributes match
+ * the Tabler outline icons 1:1, so the rendered result is unchanged.
+ */
+function ControlIcon({ size = 24, children }: React.PropsWithChildren<ControlIconProps>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** Close control — replica of `@tabler/icons-react` `IconX` */
+export function IconX({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path d="M18 6l-12 12" />
+      <path d="M6 6l12 12" />
+    </ControlIcon>
+  );
+}
+
+/** Expand control — replica of `@tabler/icons-react` `IconPlus` */
+export function IconPlus({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path d="M12 5l0 14" />
+      <path d="M5 12l14 0" />
+    </ControlIcon>
+  );
+}
+
+/** Collapse control — replica of `@tabler/icons-react` `IconMinus` */
+export function IconMinus({ size }: ControlIconProps) {
+  return (
+    <ControlIcon size={size}>
+      <path d="M5 12l14 0" />
+    </ControlIcon>
+  );
+}

--- a/package/src/Window.tsx
+++ b/package/src/Window.tsx
@@ -18,8 +18,8 @@ import {
   type MantineRadius,
   type MantineShadow,
 } from '@mantine/core';
-import { IconMinus, IconPlus, IconX } from '@tabler/icons-react';
 import React from 'react';
+import { IconMinus, IconPlus, IconX } from './ControlIcons';
 import { useMantineWindow } from './hooks/use-mantine-window';
 import { useResponsiveValue, type ResponsiveValue } from './hooks/use-responsive-value';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,7 +1561,6 @@ __metadata:
   peerDependencies:
     "@mantine/core": ">=9.0.0"
     "@mantine/hooks": ">=9.0.0"
-    "@tabler/icons-react": ^3.34.0
     react: ^18.x || ^19.x
     react-dom: ^18.x || ^19.x
   languageName: unknown


### PR DESCRIPTION
## Problem

Issue #39: consumers building `@gfazioli/mantine-window` in a Vite SSR project (Rolldown optimizer) get a `LARGE_BARREL_MODULES` warning during dependency optimization, because the package imported `IconMinus`/`IconPlus`/`IconX` from the `@tabler/icons-react` barrel (6149 re-exports). Since `@tabler/icons-react` was an external peer dependency, the published `dist` preserved the barrel import.

**Scope note:** this is a dev/SSR dependency-optimization *warning*, not a runtime or production-build error. `@tabler/icons-react` ships `sideEffects: false`, so production bundles were already tree-shaken down to the 3 icons, and the barrel itself belongs to Tabler rather than to this package. Even so, the package can avoid contributing to the warning altogether.

## Fix

- Add `package/src/ControlIcons.tsx` with three inline SVG icons (`IconX`, `IconPlus`, `IconMinus`) — geometry and stroke attributes copied 1:1 from `@tabler/icons-react` v3.44.0 outline icons.
- `Window.tsx` now imports the control icons from `./ControlIcons` instead of the Tabler barrel.
- Remove `@tabler/icons-react` from `peerDependencies` — consumers no longer need to install it for this component.

The `@rolldown/plugin-transform-imports` approach suggested in the issue was not applicable: this package builds with **Rollup**, not Rolldown. Inlining the three trivial control icons is the same approach Mantine core itself uses (`CloseButton` renders an inline SVG), removes a peer dependency, and eliminates the warning at the source.

## Verification

- `dist` no longer contains any real `@tabler/icons-react` import/require.
- SSR markup comparison (`renderToStaticMarkup`): the SVG emitted by each inline icon is byte-for-byte identical to Tabler's (modulo the unused `tabler-icon` className — no stylesheet targets it).
- `yarn test` green: format + typecheck (package + docs) + lint + jest **154/154**.
- Visual check on the docs dev server: window controls render unchanged.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window controls now use built-in icons, reducing reliance on an external icon source.

* **Bug Fixes**
  * Improved consistency of the window header controls across the app.

* **Chores**
  * Updated package dependencies to remove an unneeded icon dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->