### PR TITLE
feat: drag and resize lifecycle callbacks

### DIFF
--- a/docs/demos/Window.demo.dragResizeLifecycle.tsx
+++ b/docs/demos/Window.demo.dragResizeLifecycle.tsx
@@ -1,0 +1,116 @@
+import { Window } from '@gfazioli/mantine-window';
+import { Badge, Box, Code, Group, Stack, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { useState } from 'react';
+
+const code = `import { useState } from 'react';
+import { Window } from '@gfazioli/mantine-window';
+import { Badge, Box, Code, Group, Stack, Text } from '@mantine/core';
+
+function Demo() {
+  const [gesture, setGesture] = useState<'idle' | 'dragging' | 'resizing'>('idle');
+  const [during, setDuring] = useState(0);
+  const [atEnd, setAtEnd] = useState(0);
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 500 }}>
+      <Window
+        title="Drag or resize me"
+        opened
+        defaultX={50} defaultY={50}
+        defaultWidth={420} defaultHeight={300}
+        persistState={false}
+        withinPortal={false}
+        // Continuous: fires on every frame of the gesture
+        onPositionChange={() => setDuring((n) => n + 1)}
+        onSizeChange={() => setDuring((n) => n + 1)}
+        // Lifecycle: one call each, at the edges of the gesture
+        onDragStart={() => setGesture('dragging')}
+        onDragEnd={() => { setGesture('idle'); setAtEnd((n) => n + 1); }}
+        onResizeStart={() => setGesture('resizing')}
+        onResizeEnd={() => { setGesture('idle'); setAtEnd((n) => n + 1); }}
+      >
+        <Stack gap="md" p="xs">
+          <Group>
+            <Text size="sm">State:</Text>
+            <Badge color={gesture === 'idle' ? 'gray' : 'blue'}>{gesture}</Badge>
+          </Group>
+
+          <Text size="sm">
+            Writes if you persisted on every change: <Code>{during}</Code>
+          </Text>
+          <Text size="sm">
+            Writes if you persisted on end only: <Code>{atEnd}</Code>
+          </Text>
+
+          <Text size="xs" c="dimmed">
+            Both numbers describe the same gesture. The second one is why the lifecycle
+            callbacks exist.
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+`;
+
+function Demo() {
+  const [gesture, setGesture] = useState<'idle' | 'dragging' | 'resizing'>('idle');
+  const [during, setDuring] = useState(0);
+  const [atEnd, setAtEnd] = useState(0);
+
+  return (
+    <Box pos="relative" style={{ width: '100%', height: 500 }}>
+      <Window
+        title="Drag or resize me"
+        opened
+        defaultX={50}
+        defaultY={50}
+        defaultWidth={420}
+        defaultHeight={300}
+        persistState={false}
+        withinPortal={false}
+        // Continuous: fires on every frame of the gesture
+        onPositionChange={() => setDuring((n) => n + 1)}
+        onSizeChange={() => setDuring((n) => n + 1)}
+        // Lifecycle: one call each, at the edges of the gesture
+        onDragStart={() => setGesture('dragging')}
+        onDragEnd={() => {
+          setGesture('idle');
+          setAtEnd((n) => n + 1);
+        }}
+        onResizeStart={() => setGesture('resizing')}
+        onResizeEnd={() => {
+          setGesture('idle');
+          setAtEnd((n) => n + 1);
+        }}
+      >
+        <Stack gap="md" p="xs">
+          <Group>
+            <Text size="sm">State:</Text>
+            <Badge color={gesture === 'idle' ? 'gray' : 'blue'}>{gesture}</Badge>
+          </Group>
+
+          <Text size="sm">
+            Writes if you persisted on every change: <Code>{during}</Code>
+          </Text>
+          <Text size="sm">
+            Writes if you persisted on end only: <Code>{atEnd}</Code>
+          </Text>
+
+          <Text size="xs" c="dimmed">
+            Both numbers describe the same gesture. The second one is why the lifecycle callbacks
+            exist.
+          </Text>
+        </Stack>
+      </Window>
+    </Box>
+  );
+}
+
+export const dragResizeLifecycle: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -1,4 +1,5 @@
 export { callbacks } from './Window.demo.callbacks';
+export { dragResizeLifecycle } from './Window.demo.dragResizeLifecycle';
 export { centered } from './Window.demo.centered';
 export { configurator } from './Window.demo.configurator';
 export { contextMenu } from './Window.demo.contextMenu';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -160,6 +160,16 @@ Use `onPositionChange` and `onSizeChange` callbacks to respond to window movemen
 
 <Demo data={demos.callbacks} />
 
+### Drag and Resize Lifecycle
+
+`onPositionChange` and `onSizeChange` fire continuously, on every frame of a gesture. Four more callbacks mark its edges instead: `onDragStart`, `onDragEnd`, `onResizeStart` and `onResizeEnd`. They mirror the set that Mantine core's `FloatingWindow` exposes.
+
+The edges are what make a gesture composable. Persist the layout once, on end, instead of debouncing every frame by hand; pause an expensive child, an iframe or a video while the user drags and resume after; show a snap guide or a dimension badge only while the gesture runs; record a single undo entry per gesture rather than one per pixel.
+
+Each start is paired with exactly one end. A press on a resize handle, on an interactive child (input, button, link, …) or on a `data-no-window-drag` region does not open a drag, so no `onDragStart` fires there either — and a resize never emits drag callbacks, nor the other way round. Unmounting mid-gesture still fires the matching end, so a paused child is never left paused.
+
+<Demo data={demos.dragResizeLifecycle} />
+
 ## Multiple Windows
 
 You can render multiple windows in the same container. Each window maintains its own z-index and can be brought to the front by clicking on it. Use unique `id` props to ensure proper state persistence.

--- a/package/src/Window.test.tsx
+++ b/package/src/Window.test.tsx
@@ -529,6 +529,179 @@ describe('Window', () => {
     expect(onPositionChange).not.toHaveBeenCalled();
   });
 
+  // ─── Drag / resize lifecycle callbacks ────────────────────────────────
+
+  it('fires onDragStart once and onDragEnd once for a drag gesture, in order', () => {
+    const calls: string[] = [];
+    const { container } = renderWithMantine(
+      <Window
+        opened
+        title="Drag lifecycle"
+        defaultX={100}
+        defaultY={100}
+        draggable="header"
+        withinPortal={false}
+        onDragStart={() => calls.push('start')}
+        onDragEnd={() => calls.push('end')}
+      />
+    );
+    const header = container.querySelector('.mantine-Window-header') as HTMLElement;
+
+    fireEvent.mouseDown(header, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 160 });
+    fireEvent.mouseMove(document, { clientX: 170, clientY: 190 });
+    fireEvent.mouseUp(document);
+
+    // Once each, and never an end before its start — several moves must not multiply them.
+    expect(calls).toEqual(['start', 'end']);
+  });
+
+  it('fires onResizeStart once and onResizeEnd once for a resize gesture, in order', () => {
+    const calls: string[] = [];
+    const { container } = renderWithMantine(
+      <Window
+        opened
+        title="Resize lifecycle"
+        defaultWidth={400}
+        defaultHeight={300}
+        resizable="both"
+        withinPortal={false}
+        onResizeStart={() => calls.push('start')}
+        onResizeEnd={() => calls.push('end')}
+      />
+    );
+    const handle = container.querySelector('[data-resize-handle]') as HTMLElement;
+
+    fireEvent.mouseDown(handle, { clientX: 400, clientY: 300 });
+    fireEvent.mouseMove(document, { clientX: 450, clientY: 350 });
+    fireEvent.mouseUp(document);
+
+    expect(calls).toEqual(['start', 'end']);
+  });
+
+  it('does not fire drag callbacks during a resize, nor resize callbacks during a drag', () => {
+    // The global mouseup listener ends both gestures at once, so without a per-hook
+    // guard a plain resize would emit an unpaired onDragEnd (and vice versa).
+    const onDragStart = jest.fn();
+    const onDragEnd = jest.fn();
+    const onResizeStart = jest.fn();
+    const onResizeEnd = jest.fn();
+    const { container } = renderWithMantine(
+      <Window
+        opened
+        title="No cross talk"
+        defaultX={100}
+        defaultY={100}
+        defaultWidth={400}
+        defaultHeight={300}
+        draggable="header"
+        resizable="both"
+        withinPortal={false}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onResizeStart={onResizeStart}
+        onResizeEnd={onResizeEnd}
+      />
+    );
+
+    const handle = container.querySelector('[data-resize-handle]') as HTMLElement;
+    fireEvent.mouseDown(handle, { clientX: 400, clientY: 300 });
+    fireEvent.mouseMove(document, { clientX: 450, clientY: 350 });
+    fireEvent.mouseUp(document);
+
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onDragStart).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+
+    const header = container.querySelector('.mantine-Window-header') as HTMLElement;
+    fireEvent.mouseDown(header, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 160 });
+    fireEvent.mouseUp(document);
+
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onDragStart when the pointer starts on an interactive child', () => {
+    // Same bail-out that keeps a child input focusable must also keep the gesture
+    // from opening: a start with no matching end leaks consumer state.
+    const onDragStart = jest.fn();
+    const onDragEnd = jest.fn();
+    const { container } = renderWithMantine(
+      <Window
+        opened
+        title="Interactive child"
+        defaultX={100}
+        defaultY={100}
+        draggable="both"
+        withinPortal={false}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+      >
+        <input aria-label="Inner input" data-testid="lifecycle-input" />
+      </Window>
+    );
+    const input = container.querySelector('[data-testid="lifecycle-input"]') as HTMLElement;
+
+    fireEvent.mouseDown(input, { clientX: 120, clientY: 120 });
+    fireEvent.mouseMove(document, { clientX: 220, clientY: 240 });
+    fireEvent.mouseUp(document);
+
+    expect(onDragStart).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it('closes an in-flight drag gesture on unmount', () => {
+    const onDragStart = jest.fn();
+    const onDragEnd = jest.fn();
+    const { container, unmount } = renderWithMantine(
+      <Window
+        opened
+        title="Unmount mid drag"
+        defaultX={100}
+        defaultY={100}
+        draggable="header"
+        withinPortal={false}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+      />
+    );
+    const header = container.querySelector('.mantine-Window-header') as HTMLElement;
+
+    fireEvent.mouseDown(header, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 160 });
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire any lifecycle callback on unmount without a gesture', () => {
+    const onDragEnd = jest.fn();
+    const onResizeEnd = jest.fn();
+    const { unmount } = renderWithMantine(
+      <Window
+        opened
+        title="Clean unmount"
+        withinPortal={false}
+        draggable="header"
+        resizable="both"
+        onDragEnd={onDragEnd}
+        onResizeEnd={onResizeEnd}
+      />
+    );
+
+    unmount();
+
+    expect(onDragEnd).not.toHaveBeenCalled();
+    expect(onResizeEnd).not.toHaveBeenCalled();
+  });
+
   it('still starts a drag when mousedown originates on non-interactive content', () => {
     const onPositionChange = jest.fn();
     const { container } = renderWithMantine(

--- a/package/src/Window.tsx
+++ b/package/src/Window.tsx
@@ -222,6 +222,22 @@ export interface WindowBaseProps {
   /** Called when the window is resized. Receives pixel values. */
   onSizeChange?: (size: { width: number; height: number }) => void;
 
+  /**
+   * Called once when a drag gesture starts, after the window has decided the pointer
+   * actually starts a drag: a press on a resize handle, on an interactive child
+   * (input, button, link, …) or on a `data-no-window-drag` region does not fire it.
+   */
+  onDragStart?: () => void;
+
+  /** Called once when a drag gesture ends. Always paired with a preceding `onDragStart`. */
+  onDragEnd?: () => void;
+
+  /** Called once when a resize gesture starts. */
+  onResizeStart?: () => void;
+
+  /** Called once when a resize gesture ends. Always paired with a preceding `onResizeStart`. */
+  onResizeEnd?: () => void;
+
   // ─── Z-index management (ignored when inside a WindowGroup) ─────────
 
   /**
@@ -337,6 +353,10 @@ export const Window = factory<WindowFactory>((_props) => {
     defaultHeight,
     onPositionChange,
     onSizeChange,
+    onDragStart,
+    onDragEnd,
+    onResizeStart,
+    onResizeEnd,
     initialZIndex,
     maxZIndex,
     withBorder,

--- a/package/src/hooks/use-mantine-window.ts
+++ b/package/src/hooks/use-mantine-window.ts
@@ -37,6 +37,10 @@ export function useMantineWindow(props: WindowBaseProps) {
     dragBounds: dragBoundsProp,
     onPositionChange,
     onSizeChange,
+    onDragStart,
+    onDragEnd,
+    onResizeStart,
+    onResizeEnd,
     initialZIndex,
     maxZIndex,
   } = props;
@@ -271,6 +275,8 @@ export function useMantineWindow(props: WindowBaseProps) {
     windowRef,
     setPosition: state.setPosition,
     bringToFront: groupBringToFront,
+    onDragStart,
+    onDragEnd,
   });
 
   // ─── Resize functionality ───────────────────────────────────────────
@@ -282,6 +288,8 @@ export function useMantineWindow(props: WindowBaseProps) {
     setPosition: state.setPosition,
     setSize: state.setSize,
     bringToFront: groupBringToFront,
+    onResizeStart,
+    onResizeEnd,
   });
 
   const mergedRef = useMergedRef(windowRef);
@@ -349,6 +357,11 @@ export function useMantineWindow(props: WindowBaseProps) {
       } as EventListenerOptions);
       document.removeEventListener('touchend', handleTouchEnd);
       document.removeEventListener('touchcancel', handleTouchEnd);
+      // Unmounting mid-gesture must still close it: a consumer that paused an expensive
+      // child on onDragStart, or opened an undo entry, would otherwise never be told the
+      // gesture is over. Both helpers no-op when their own gesture was not active.
+      dragRef.current.handleDragEnd();
+      resizeRef.current.handleResizeEnd();
       document.body.style.userSelect = '';
       document.body.style.cursor = '';
     };

--- a/package/src/hooks/use-window-drag.ts
+++ b/package/src/hooks/use-window-drag.ts
@@ -50,6 +50,8 @@ export interface UseWindowDragOptions {
   windowRef: React.RefObject<HTMLDivElement | null>;
   setPosition: (position: WindowPosition) => void;
   bringToFront: () => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 }
 
 export function useWindowDrag(options: UseWindowDragOptions) {
@@ -66,10 +68,19 @@ export function useWindowDrag(options: UseWindowDragOptions) {
     windowRef,
     setPosition,
     bringToFront,
+    onDragStart,
+    onDragEnd,
   } = options;
 
   const isDragging = useRef(false);
   const dragStart = useRef({ x: 0, y: 0 });
+
+  // Kept in refs so a consumer passing an inline arrow does not re-create the
+  // memoized pointer handlers on every render.
+  const onDragStartRef = useRef(onDragStart);
+  onDragStartRef.current = onDragStart;
+  const onDragEndRef = useRef(onDragEnd);
+  onDragEndRef.current = onDragEnd;
 
   const applyBounds = useCallback(
     (newX: number, newY: number): { x: number; y: number } => {
@@ -129,6 +140,9 @@ export function useWindowDrag(options: UseWindowDragOptions) {
       };
       document.body.style.userSelect = 'none';
       e.preventDefault();
+      // Emitted only past the bail-outs above: a mousedown on a resize handle or on an
+      // interactive child is not a drag, and must not open a gesture that never closes.
+      onDragStartRef.current?.();
     },
     [positionPx, bringToFront]
   );
@@ -154,6 +168,7 @@ export function useWindowDrag(options: UseWindowDragOptions) {
       };
       document.body.style.userSelect = 'none';
       e.preventDefault();
+      onDragStartRef.current?.();
     },
     [positionPx, bringToFront]
   );
@@ -174,7 +189,13 @@ export function useWindowDrag(options: UseWindowDragOptions) {
   );
 
   const handleDragEnd = useCallback(() => {
+    // The global mouseup/touchend listener calls this whenever EITHER gesture is
+    // active, so a plain resize would otherwise emit an unpaired onDragEnd.
+    const wasDragging = isDragging.current;
     isDragging.current = false;
+    if (wasDragging) {
+      onDragEndRef.current?.();
+    }
   }, []);
 
   return {

--- a/package/src/hooks/use-window-resize.ts
+++ b/package/src/hooks/use-window-resize.ts
@@ -35,10 +35,28 @@ export interface UseWindowResizeOptions {
   setPosition: (position: WindowPosition) => void;
   setSize: (size: WindowSize) => void;
   bringToFront: () => void;
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
 }
 
 export function useWindowResize(options: UseWindowResizeOptions) {
-  const { positionPx, sizePx, constraintsPx, setPosition, setSize, bringToFront } = options;
+  const {
+    positionPx,
+    sizePx,
+    constraintsPx,
+    setPosition,
+    setSize,
+    bringToFront,
+    onResizeStart,
+    onResizeEnd,
+  } = options;
+
+  // Kept in refs so an inline arrow from the consumer does not re-create the
+  // memoized handler map on every render.
+  const onResizeStartRef = useRef(onResizeStart);
+  onResizeStartRef.current = onResizeStart;
+  const onResizeEndRef = useRef(onResizeEnd);
+  onResizeEndRef.current = onResizeEnd;
 
   const isResizing = useRef(false);
   const resizeDirection = useRef<ResizeDirection | ''>('');
@@ -175,6 +193,7 @@ export function useWindowResize(options: UseWindowResizeOptions) {
         document.body.style.userSelect = 'none';
         e.preventDefault();
         e.stopPropagation();
+        onResizeStartRef.current?.();
       };
 
       const onTouchStart = (e: React.TouchEvent) => {
@@ -192,6 +211,7 @@ export function useWindowResize(options: UseWindowResizeOptions) {
         };
         document.body.style.userSelect = 'none';
         e.stopPropagation();
+        onResizeStartRef.current?.();
       };
 
       return { onMouseDown, onTouchStart };
@@ -214,7 +234,13 @@ export function useWindowResize(options: UseWindowResizeOptions) {
   );
 
   const handleResizeEnd = useCallback(() => {
+    // Same guard as the drag hook: the global listener ends both gestures at once,
+    // so a plain drag must not emit an unpaired onResizeEnd.
+    const wasResizing = isResizing.current;
     isResizing.current = false;
+    if (wasResizing) {
+      onResizeEndRef.current?.();
+    }
   }, []);
 
   return {


### PR DESCRIPTION
Closes #47.

Adds `onDragStart`, `onDragEnd`, `onResizeStart` and `onResizeEnd`, completing the set that Mantine core `FloatingWindow` exposes — start, change and end for both gestures. `Window` had only the two *change* callbacks, and those fire on every frame of a gesture, so persisting a layout meant debouncing by hand and there was no moment to pause an expensive child, show a snap guide, or record a single undo entry per gesture.

| Interaction | start | change | end |
|---|---|---|---|
| Drag | `onDragStart` **(new)** | `onPositionChange` | `onDragEnd` **(new)** |
| Resize | `onResizeStart` **(new)** | `onSizeChange` | `onResizeEnd` **(new)** |

## Why this is additive, checked rather than assumed

Four optional props, no default or behaviour change → **minor**.

`onDragStart`/`onDragEnd` are real React DOM event names, so shadowing was the thing to check. `WindowProps extends BoxProps, WindowBaseProps, StylesApiProps` — **not** `ElementProps<div>` — so those names were never in the public type and no existing usage changes meaning. They are destructured out of the props spread, which is what keeps them off the root element (leaking them would have wired the native HTML5 drag events).

## Two things the implementation had to get right

**No cross-talk.** The global `mouseup`/`touchend` listener calls `handleDragEnd()` **and** `handleResizeEnd()` whenever *either* gesture is active. A naive end callback would therefore emit an unpaired `onDragEnd` during a plain resize. Each hook now checks its own in-flight ref before firing.

I confirmed the test for this actually tests it: removing the guard makes it fail with `Expected number of calls: 0 / Received number of calls: 1`. Restored, it passes.

**No start without a real gesture.** `onDragStart` is emitted only past the existing bail-outs — a press on a resize handle, on an interactive child (`input`, `button`, `a[href]`, …) or on a `data-no-window-drag` region does not open a gesture that would never close. Unmounting mid-gesture fires the matching end, so a consumer that paused something on start is never left paused.

There is no keyboard drag or resize in this component, so core's caveat about its resize callbacks not firing for keyboard resize has no equivalent here. Stated in the docs so the difference is deliberate rather than silent.

## Verified with real pointer events, not only jsdom

Driven in Chrome with `Input.dispatchMouseEvent`:

| Moment | State | Writes *during* | Writes *at end* |
|---|---|---|---|
| Before | `idle` | 0 | 0 |
| Press on header | **`dragging`** | 0 | 0 |
| Mid-drag (8 moves) | `dragging` | **8** | 0 |
| Release | `idle` | 8 | **1** |
| Press on resize handle | **`resizing`** | 8 | 1 (no spurious end) |
| Release | `idle` | **20** | **2** |

One drag and one resize: 20 continuous calls against 2 lifecycle calls, every start paired with exactly one end.

## What is in the diff

- 4 props on `Window`, threaded through `useMantineWindow` into the drag and resize hooks, held in refs so an inline arrow from the consumer does not re-create the memoized pointer handlers
- **6 new tests**: order and exactly-once for each gesture, no cross-talk in either direction, no `onDragStart` on an interactive child, end fired on unmount mid-gesture, and nothing fired on a clean unmount
- New demo `Drag and Resize Lifecycle` plus a `docs.mdx` section; the demo counts the two kinds of write side by side, which makes the point faster than prose

## Test plan
- [x] `yarn test` — 160 passing
- [x] `yarn build`, `yarn docgen` (the 4 props appear in the Props table), `yarn docs:build` with `docs/.next` cleared
- [x] Real drag and resize in Chrome, numbers above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag and resize lifecycle callbacks: `onDragStart`, `onDragEnd`, `onResizeStart`, and `onResizeEnd`.
  * Callbacks fire once per valid gesture and remain correctly paired when gestures are interrupted.
  * Added documentation and an interactive demo illustrating lifecycle and continuous change callbacks.

* **Bug Fixes**
  * Prevented drag callbacks from firing during resizing or interactions with excluded elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->